### PR TITLE
feat: adds selectableCheck to callbacks array

### DIFF
--- a/lib/ConfigUtils.d.ts
+++ b/lib/ConfigUtils.d.ts
@@ -101,5 +101,6 @@ export interface IProps {
     downloadReady?: any;
     downloadComplete?: any;
     options?: any;
+    selectableCheck?: any;
 }
 export declare const propsToOptions: (props: any) => Promise<any>;

--- a/lib/ConfigUtils.js
+++ b/lib/ConfigUtils.js
@@ -75,7 +75,7 @@ exports.propsToOptions = function (props) { return __awaiter(void 0, void 0, voi
                     'groupVisibilityChanged', 'groupClick', 'groupDblClick', 'groupContext', 'groupTap', 'groupDblTap', 'groupTapHold',
                     'movableRowsSendingStart', 'movableRowsSent', 'movableRowsSentFailed', 'movableRowsSendingStop', 'movableRowsReceivingStart', 'movableRowsReceived', 'movableRowsReceivedFailed', 'movableRowsReceivingStop',
                     'validationFailed', 'clipboardCopied', 'clipboardPasted', 'clipboardPasteError',
-                    'downloadReady', 'downloadComplete'];
+                    'downloadReady', 'downloadComplete', 'selectableCheck'];
                 for (_a = 0, callbackNames_1 = callbackNames; _a < callbackNames_1.length; _a++) {
                     callbackName = callbackNames_1[_a];
                     output[callbackName] = props[callbackName] || NOOPS;


### PR DESCRIPTION
This PR add the following functionality to the react-tabulator:

1. selectableCheck: A method used to define whether a row can be selected or not. For further info, check [docs](http://tabulator.info/docs/4.7/select#setup-eligible.