### PR TITLE
Remove unimplemented ES6 module declaration

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 14.x]
+        node-version: [10.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "React Tabulator is based on tabulator - a JS table library with many advanced features.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "module": "es/index.js",
   "files": [
     "css",
     "es",


### PR DESCRIPTION
ES6 module support is declared, but implemented. This PR removes the declaration.

Fixes  #207 