### PR TITLE
fix: missing callback name - selectableCheck

### DIFF
--- a/lib/ConfigUtils.js
+++ b/lib/ConfigUtils.js
@@ -75,7 +75,7 @@ exports.propsToOptions = function (props) { return __awaiter(void 0, void 0, voi
                     'groupVisibilityChanged', 'groupClick', 'groupDblClick', 'groupContext', 'groupTap', 'groupDblTap', 'groupTapHold',
                     'movableRowsSendingStart', 'movableRowsSent', 'movableRowsSentFailed', 'movableRowsSendingStop', 'movableRowsReceivingStart', 'movableRowsReceived', 'movableRowsReceivedFailed', 'movableRowsReceivingStop',
                     'validationFailed', 'clipboardCopied', 'clipboardPasted', 'clipboardPasteError',
-                    'downloadReady', 'downloadComplete'];
+                    'downloadReady', 'downloadComplete', 'selectableCheck'];
                 for (_a = 0, callbackNames_1 = callbackNames; _a < callbackNames_1.length; _a++) {
                     callbackName = callbackNames_1[_a];
                     output[callbackName] = props[callbackName] || NOOPS;


### PR DESCRIPTION
The `selectableCheck` function name is defined in Config Utils types but is missing from `ConfigUtils.js` file's callback names array, a quick update via node_modules for this package made the functionality work.