### PR TITLE
Upgrading react tag autocomplete to 7.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "date-fns": "v2.0.0-alpha.25",
     "dotenv": "^8.2.0",
     "pick-react-known-prop": "^0.1.5",
-    "react-tag-autocomplete": "^5.7.1",
+    "react-tag-autocomplete": "^7.2.0",
     "tabulator-tables": "^4.4.3"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,8 +85,9 @@
     "@types/react" "*"
 
 "@types/react-tag-autocomplete@^5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@types/react-tag-autocomplete/-/react-tag-autocomplete-5.6.0.tgz#26a9af61f78e0d6a669b37a09ddd97dbb30bffcc"
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@types/react-tag-autocomplete/-/react-tag-autocomplete-5.12.0.tgz#bcebefd07abd20ee7a1d9594cf4f2f0297625868"
+  integrity sha512-QvPBUrXnkU5e3EaHiXQcI0oRsV1JwvL2vvgXtY5x7SkW19O3FRGFdcPg4+SA545+pcIsijf1O2wQ/sCCTeEe9w==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
Currently due to this react tag autocomplete module being very outdated and using React 15 and 16, anyone who is using React >18 has many issues that come up due to having two different copies of React hard conflicting. v7 aligns with React v18.